### PR TITLE
fix: consolidate browser-extension(s) bindings - no more naming chaos

### DIFF
--- a/docs/bindings/00-index.md
+++ b/docs/bindings/00-index.md
@@ -131,19 +131,14 @@ _No frontend bindings defined yet._
 | [rest-api-standards](./categories/api/rest-api-standards.md) | 0.1.0 | This binding implements our simplicity tenet by leveraging the established semantics of HTTP rather than inventing custom conventions. When APIs fo... |
 | [rest-first-api-design](./categories/api/rest-first-api-design.md) | 0.1.0 | This binding implements our simplicity tenet by establishing REST as the foundation for API design, avoiding the accidental complexity that often c... |
 
-## Browser-extension Bindings
-
-| ID | Version | Summary |
-|---|---|---|
-| [cross-browser-compatibility](./categories/browser-extension/cross-browser-compatibility.md) | 0.1.0 | This binding implements our adaptability-and-reversibility tenet by ensuring extensions can adapt to different browser environments and evolve as b... |
-| [extension-permissions-model](./categories/browser-extension/extension-permissions-model.md) | 0.1.0 | This binding implements our no-secret-suppression tenet by making extension capabilities and data access explicit to users. Browser extensions oper... |
-| [extension-update-strategy](./categories/browser-extension/extension-update-strategy.md) | 0.1.0 | This binding implements our deliver-value-continuously tenet by ensuring that improvements and fixes reach users efficiently while maintaining trus... |
-
 ## Browser-extensions Bindings
 
 | ID | Version | Summary |
 |---|---|---|
 | [browser-extension-security-patterns](./categories/browser-extensions/browser-extension-security-patterns.md) | 0.1.0 | This binding implements our explicit-over-implicit tenet by requiring that browser extension security concerns be visible, documented, and intentio... |
+| [cross-browser-compatibility](./categories/browser-extensions/cross-browser-compatibility.md) | 0.1.0 | This binding implements our adaptability-and-reversibility tenet by ensuring extensions can adapt to different browser environments and evolve as b... |
+| [extension-permissions-model](./categories/browser-extensions/extension-permissions-model.md) | 0.1.0 | This binding implements our no-secret-suppression tenet by making extension capabilities and data access explicit to users. Browser extensions oper... |
+| [extension-update-strategy](./categories/browser-extensions/extension-update-strategy.md) | 0.1.0 | This binding implements our deliver-value-continuously tenet by ensuring that improvements and fixes reach users efficiently while maintaining trus... |
 
 ## Database Bindings
 

--- a/docs/bindings/categories/browser-extensions/cross-browser-compatibility.md
+++ b/docs/bindings/categories/browser-extensions/cross-browser-compatibility.md
@@ -103,6 +103,6 @@ Always provide alternative experiences for other browsers when possible.
 
 ## Related Bindings
 
-- [extension-permissions-model](../../docs/bindings/categories/browser-extension/extension-permissions-model.md): Permission differences across browsers
-- [extension-update-strategy](../../docs/bindings/categories/browser-extension/extension-update-strategy.md): Update mechanisms across browser stores
+- [extension-permissions-model](extension-permissions-model.md): Permission differences across browsers
+- [extension-update-strategy](extension-update-strategy.md): Update mechanisms across browser stores
 - [preferred-technology-patterns](../../core/preferred-technology-patterns.md): Technology choices for cross-browser development

--- a/docs/bindings/categories/browser-extensions/extension-permissions-model.md
+++ b/docs/bindings/categories/browser-extensions/extension-permissions-model.md
@@ -100,6 +100,6 @@ Always document exceptions and their security implications.
 
 ## Related Bindings
 
-- [extension-update-strategy](../../docs/bindings/categories/browser-extension/extension-update-strategy.md): Communicating permission changes during updates
-- [cross-browser-compatibility](../../docs/bindings/categories/browser-extension/cross-browser-compatibility.md): Permission differences across browsers
+- [extension-update-strategy](extension-update-strategy.md): Communicating permission changes during updates
+- [cross-browser-compatibility](cross-browser-compatibility.md): Permission differences across browsers
 - [secrets-management-practices](../../security/secrets-management-practices.md): Protecting sensitive data in extensions

--- a/docs/bindings/categories/browser-extensions/extension-update-strategy.md
+++ b/docs/bindings/categories/browser-extensions/extension-update-strategy.md
@@ -102,5 +102,5 @@ Always prioritize user communication even in exceptional circumstances.
 
 ## Related Bindings
 
-- [extension-permissions-model](../../docs/bindings/categories/browser-extension/extension-permissions-model.md): Managing permission changes during updates
-- [cross-browser-compatibility](../../docs/bindings/categories/browser-extension/cross-browser-compatibility.md): Update compatibility across browsers
+- [extension-permissions-model](extension-permissions-model.md): Managing permission changes during updates
+- [cross-browser-compatibility](cross-browser-compatibility.md): Update compatibility across browsers


### PR DESCRIPTION
## Problem
Repository had both `browser-extension/` (singular) and `browser-extensions/` (plural) directories. Classic naming inconsistency causing confusion and fragmentation.

## Solution
Consolidated everything into `browser-extensions/` (plural) to match other category naming patterns.

## Changes
- **Moved 3 bindings** from singular to plural directory
- **Fixed cross-references** in moved files  
- **Updated glance.md** to reflect all 4 bindings
- **Removed empty directory** after migration
- **Reindexed** to update generated files

## Result
Single source of truth for browser extension guidance. No more hunting across two directories.

**Before:** `browser-extension/` + `browser-extensions/` (4 files split)  
**After:** `browser-extensions/` only (4 files unified)

## Test Plan
- [x] YAML front-matter validation passes
- [x] Index consistency checks pass  
- [x] Cross-references work correctly
- [x] No broken links or missing files

Ready to merge - consolidation complete.